### PR TITLE
Fix encryption of non-text files

### DIFF
--- a/hooks/useTaco.ts
+++ b/hooks/useTaco.ts
@@ -88,15 +88,11 @@ export default function useTaco({ ritualId, domain, provider }: UseTacoParams) {
       if (!isInit || !provider) return;
       if (networkError) throw new Error(networkError);
 
-      // Ensure we always provide a string to `encrypt`
-      const payload =
-        typeof data === "string" ? data : new TextDecoder().decode(data);
-
       try {
         const messageKit = await encrypt(
           provider,
           domain,
-          payload,
+          data,
           condition,
           ritualId,
           encryptorSigner


### PR DESCRIPTION
We were assuming that the file to be upload would be a Text file. 

With these changes, any type of file can be encrypted (and decrypted later) since we are managing them as Byte array.